### PR TITLE
Added UTF-8 source encoding in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -638,6 +638,7 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
         <lucene.version>3.0.1</lucene.version>
         <spock.version>0.5-groovy-1.7</spock.version>
         <commons.codec.version>1.4</commons.codec.version>
+	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <pluginRepositories>


### PR DESCRIPTION
Fixes [WARNING] Using platform encoding (MacRoman actually) to copy filtered resources, i.e. build is platform dependent!
message when building on OS X.  RedHat EL 6.4 also had a similar warning.
